### PR TITLE
compile and run on Java 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,4 +12,8 @@ libraryDependencies ++= Seq(
   "com.novocode" % "junit-interface" % "0.9" % "test->default"
 )
 
+javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+
+scalacOptions += "-target:jvm-1.7"
+
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")


### PR DESCRIPTION
update build.sbt to be able to compile and run this tutorial on Java 8. ASM complains about an unknown class format.
